### PR TITLE
Fix issue with padding when IncludeLineBreak is false

### DIFF
--- a/LoggingAdvanced.Console/AdvancedConsoleLogger.cs
+++ b/LoggingAdvanced.Console/AdvancedConsoleLogger.cs
@@ -156,7 +156,7 @@ namespace LoggingAdvanced.Console
                     GetScopeInformation(logBuilder);
 
                 // message
-                logBuilder.Append(_messagePadding);
+                logBuilder.Append((Settings.IncludeLineBreak) ? _messagePadding : _loglevelPadding);
                 var len = logBuilder.Length;
                 logBuilder.AppendLine(message);
                 logBuilder.Replace(Environment.NewLine, _newLineWithMessagePadding, len, message.Length);

--- a/README.md
+++ b/README.md
@@ -50,14 +50,14 @@ And keep the config in `appsettings.json`:
 ```cs
     AddConsoleAdvanced(Configuration.GetSection("Logging"));
 ```
-Settings file example:
+A settings file example:
 ```json
     {
         "Logging": {
             "IncludeLineBreak": true,
             "IncludeTimestamp": true,
             "IncludeZeroEventId": true,
-            "IncludeLogNamespace": true
+            "IncludeLogNamespace": true,
             "TimestampPolicy": {
                 "TimeZone": "Ulaanbaatar Standard Time",
                 "Format": "MM/dd/yyyy HH:mm:ss.fff"


### PR DESCRIPTION
This PR fixes an issue with padding of space being added in the log message between log level and message when the IncludeLineBreak is set to false.

Before the fix messages would look like this:
```
info: Program      This is the log message
```
After the fix:
```
info: Program: This is the log message
```